### PR TITLE
Fix the main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "action-tracker",
   "version": "1.2.0",
   "description": "The easy-to-use library for Google Analytics's tracking.",
-  "main": "index.js",
+  "main": "dist/action-tracker.js",
   "scripts": {
     "bump": "mversion $1 -m '%s'",
     "build": "gulp build",


### PR DESCRIPTION
# やったこと
package.jsonのmainフィールドを`dist/action-tracker.js`に修正しました

# 背景
このパッケージを利用しているプロダクトでviteを利用しようとしています。`vite build`したところ以下のエラーが発生しました

```
[commonjs--resolver] Failed to resolve entry for package "action-tracker". The package may have incorrect main/module/exports specified in its package.json.
```

現在は`main: index.js` となっていますがこの`index.js`は存在しないので依存解決に失敗するようです。`main: dist/action-tracker.js`と修正したところ`vite build`が通ることを確認しています。

この変更を取り込みv1.2.1として公開していただけると助かります

